### PR TITLE
Add linked_data_field type

### DIFF
--- a/workbench
+++ b/workbench
@@ -148,7 +148,7 @@ def create():
                 if len(parent_in_id_map_result) > 0:
                     row["field_member_of"] = str(parent_in_id_map_result[0][0])
                 else:
-                    message = f'Recovery mode was unable to find the node ID for the parent CSV row "{row["parent_id"]}" in theh CSV ID to node ID map.'
+                    message = f'Recovery mode was unable to find the node ID for the parent CSV row "{row["parent_id"]}" in the CSV ID to node ID map.'
                     print("Warning: " + message)
                     logging.warning(message)
 

--- a/workbench_fields.py
+++ b/workbench_fields.py
@@ -2067,6 +2067,117 @@ class EntityReferenceRevisionsField(WorkbenchField):
         return subvalues[0]
 
 
+class LinkedDataField(LinkField):
+    """Linked Data Field is very similar to a Link field except it has a different JSON dictionary keys serialization"""
+
+    def update(
+        self, config, field_definitions, entity, row, field_name, entity_field_values
+    ):
+        """Note: this method appends incoming CSV values to existing values, replaces existing field
+        values with incoming values, or deletes all values from fields, depending on whether
+        config['update_mode'] is 'append', 'replace', or 'delete'. It does not replace individual
+        values within fields.
+        """
+        """Parameters
+           ----------
+            config : dict
+                The configuration settings defined by workbench_config.get_config().
+            field_definitions : dict
+                The field definitions object defined by get_field_definitions().
+            entity : dict
+                The dict that will be POSTed to Drupal as JSON.
+            row : OrderedDict.
+                The current CSV record.
+            field_name : string
+                The Drupal fieldname/CSV column header.
+            entity_field_values : list
+                List of dictionaries containing existing value(s) for field_name in the entity being updated.
+            Returns
+            -------
+            dictionary
+                A dictionary representing the entity that is PATCHed to Drupal as JSON.
+        """
+        if config["update_mode"] == "delete":
+            entity[field_name] = []
+            return entity
+
+        if not row[field_name]:
+            return entity
+
+        if field_name not in entity:
+            entity[field_name] = []
+
+        if config["task"] == "update":
+            entity_id_field = "node_id"
+        else:
+            return entity
+
+        if config["update_mode"] not in ["append", "replace"]:
+            return entity
+
+        cardinality = int(field_definitions[field_name].get("cardinality", -1))
+        subvalues = []
+        if config["update_mode"] == "append":
+            # For append add existing values, then new values and then dedupe and replace
+            subvalues.extend(entity_field_values)
+        subvalues.extend(self.split_string(config, row[field_name]))
+        subvalues = self.dedupe_values(subvalues)
+
+        if -1 < cardinality < len(subvalues):
+            log_field_cardinality_violation(
+                field_name, row[entity_id_field], str(cardinality)
+            )
+            subvalues = subvalues[:cardinality]
+        entity[field_name] = subvalues
+
+        return entity
+
+    def serialize(self, config, field_definitions, field_name, field_data):
+        """Serialized values into a format consistent with Workbench's CSV-field input format."""
+        """Parameters
+           ----------
+            config : dict
+                The configuration settings defined by workbench_config.get_config().
+            field_definitions : dict
+                The field definitions object defined by get_field_definitions().
+            field_name : string
+                The Drupal fieldname/CSV column header.
+            field_data : string
+                Raw JSON from the field named 'field_name'.
+            Returns
+            -------
+            string
+                A string structured same as the Workbench CSV field data for this field type.
+                or None if there is nothing to return.
+        """
+        if "field_type" not in field_definitions[field_name]:
+            return None
+
+        subvalues = list()
+        for subvalue in field_data:
+            if (
+                "value" in subvalue
+                and subvalue["value"] is not None
+                and subvalue["value"] != ""
+            ):
+                subvalues.append(subvalue["url"] + "%%" + subvalue["value"])
+            else:
+                subvalues.append(subvalue["url"])
+
+        if len(subvalues) > 1:
+            return config["subdelimiter"].join(subvalues)
+        elif len(subvalues) == 0:
+            return None
+        else:
+            return subvalues[0]
+
+    def split_string(self, config: dict, value: str):
+        """Linked Data fields have different keys."""
+        return_list = split_link_string(config, value)
+        new_list = [{"url": d["uri"], "value": d["title"]} for d in return_list]
+        return new_list
+
+
 class WorkbenchFieldFactory:
 
     @staticmethod
@@ -2088,6 +2199,7 @@ class WorkbenchFieldFactory:
             "media_track": "MediaTrackField",
             "geolocation": "GeolocationField",
             "link": "LinkField",
+            "linked_data_field": "LinkedDataField",
         }
         """Returns a WorkbenchField subclass based on the field type."""
         if field_type in field_to_class_map:


### PR DESCRIPTION
## Link to Github issue or other discussion

Work on #929

## What does this PR do?

Adds a new class that uses existing Link field class as its parent. It overrides to alter the string splitting and serialization to handle the different JSON dictionary keys.

## What changes were made?

This work is based off of changes made #922, so it will need to be rebased once that is incorporated. Or feel free to rewrite this using the existing structure.

## How to test / verify this PR?

I copied all the existing LinkField unit tests and altered to contain the new keys. 

I've also tested this locally.

I set up a `linked_data_field` called `field_linked_subjects` in my Drupal.

Then I added a column to my spreadsheet with that name and some values from LoC using the same format as the Link fields.
`http://id.loc.gov/authorities/subjects/sh96009328%%Museum exhibits|http://id.loc.gov/authorities/subjects/sh00006830%%Museums|http://id.loc.gov/authorities/subjects/sh85005757%%Antiquities`
Then I ran my ingest and checked the object created for those entries.

## Interested Parties

@mjordan

---

## Checklist

* [x] Before opening this PR, have you opened an issue explaining what you want to to do?
* [x] Have you included some configuration and/or CSV files useful for testing this PR?
* [x] Have you written unit or integration tests if applicable?
* [ ] Does the code added in this PR require a version of Python that is higher than the current minimum version?
* [ ] If the changes in this PR require an additional Python library, have you included it in `setup.py`?
* [ ] If the changes in this PR add a new configuration option, have you provided a default for when the option is not present in the .yml file?
